### PR TITLE
add toasts, clicking reserve creates lineitem and sets hold to true

### DIFF
--- a/sylvan-library/package-lock.json
+++ b/sylvan-library/package-lock.json
@@ -25,6 +25,7 @@
         "react-dom": "^18.2.0",
         "react-redux": "^9.0.4",
         "react-scripts": "5.0.1",
+        "react-toastify": "^10.0.3",
         "web-vitals": "^2.1.4"
       }
     },
@@ -6265,6 +6266,14 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
+      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -15156,6 +15165,18 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.3.tgz",
+      "integrity": "sha512-PBJwXjFKKM73tgb6iSld4GMs9ShBWGUvc9zPHmdDgT4CdSr32iqSNh6y/fFN/tosvkTS6/tBLptDxXiXgcjvuw==",
+      "dependencies": {
+        "clsx": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-transition-group": {

--- a/sylvan-library/package.json
+++ b/sylvan-library/package.json
@@ -21,6 +21,7 @@
     "react-dom": "^18.2.0",
     "react-redux": "^9.0.4",
     "react-scripts": "5.0.1",
+    "react-toastify": "^10.0.3",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/sylvan-library/src/App.js
+++ b/sylvan-library/src/App.js
@@ -1,14 +1,29 @@
-import logo from './logo.svg';
 import './App.css';
 import './Styles/style.css';
 import Header from './Components/Header';
 import Home from './Routes/Home'
+import { toast, ToastContainer, Bounce } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
 function App() {
+
+
   return (
     <div className="App">
       {/* <Header /> */}
       <Home />
+      <ToastContainer position="bottom-right"
+        autoClose={5000}
+        hideProgressBar={false}
+        newestOnTop={false}
+        closeOnClick
+        rtl={false}
+        pauseOnFocusLoss
+        draggable
+        pauseOnHover
+        theme="dark"
+        transition={Bounce}
+/>
     </div>
   );
 }

--- a/sylvan-library/src/Components/ReservationModal.js
+++ b/sylvan-library/src/Components/ReservationModal.js
@@ -6,6 +6,8 @@ import { useDispatch, useSelector } from 'react-redux';
 import { nanoid } from '@reduxjs/toolkit';
 import { addItem, removeItem } from '../features/basket/basketSlice'
 import AvailabilityCheck from '../utilities/AvailabilityCheck';
+import addLineItem from '../apiActions/addLineItem';
+import { errorToast, successToast } from './SubComponents/Toastify';
 
 export default function ReservationModal({ show, handleClose }) {
 
@@ -16,6 +18,9 @@ export default function ReservationModal({ show, handleClose }) {
 
     //add something to the basket
     function addToBasket(itemToAdd) {
+        //adding an error as the third argument is causing both to show up onSuccess.
+        //probably just missing something 
+        addLineItem(itemToAdd, successToast(`${itemToAdd.name} was added to your basket`))
         dispatch(
             addItem({
                 id: nanoid(),

--- a/sylvan-library/src/Components/SubComponents/ReservationModal/Result.js
+++ b/sylvan-library/src/Components/SubComponents/ReservationModal/Result.js
@@ -11,6 +11,9 @@ export default function Results({item, addToBasket}) {
             <div>
                 {item.name}
             </div>
+            <div>
+                {item.inventory_id}
+            </div>
             <Button onClick={() => addToBasket(item)}>Reserve</Button>
         </div>
     )

--- a/sylvan-library/src/Components/SubComponents/ReservationModal/SearchBar.js
+++ b/sylvan-library/src/Components/SubComponents/ReservationModal/SearchBar.js
@@ -5,6 +5,7 @@ import { useState } from 'react'
 import Result from './Result'
 import { ECHO_TOKEN } from '../../../AppConstants'
 import { useSelector } from 'react-redux'
+import getReservedCardsList from '../../../apiActions/getReservedCardsList'
 
 export default function SearchBar({addToBasket}) {
 
@@ -28,7 +29,6 @@ export default function SearchBar({addToBasket}) {
         }
        
         //we probably want to filter these search results according to outstanding inventory ids that are not available, that way we're not showing stuff that isn't available
-
         return data;
     }
 
@@ -51,8 +51,6 @@ export default function SearchBar({addToBasket}) {
                     </>
                 }
                 {searchResults.map((item) => {
-                    console.log('reservedCardsInState', reservedCardsInState)
-                    console.log('item', item)
                     //just don't render them here if they are among the cards that are reserved already
                     if (reservedCardsInState && reservedCardsInState.includes(item.inventory_id)){
                         console.log('hiding something that is reserved')

--- a/sylvan-library/src/Components/SubComponents/Toastify.js
+++ b/sylvan-library/src/Components/SubComponents/Toastify.js
@@ -1,0 +1,26 @@
+import { toast } from "react-toastify";
+
+function stringCheck(text){
+    if (typeof text != 'string'){
+        return 'Someone tried to put something besides a string in here, probably Anthony'
+    }
+    //maybe something that checks for string length here?
+
+    return text
+}
+
+export function successToast(text){
+    toast.success(stringCheck(text))
+}
+
+export function warningToast(text){
+    toast.warning(stringCheck(text))
+}
+
+export function errorToast(text){
+    toast.error(stringCheck(text))
+}
+
+export function infoToast(text){
+    toast.info(stringCheck(text))
+}

--- a/sylvan-library/src/apiActions/addLineItem.js
+++ b/sylvan-library/src/apiActions/addLineItem.js
@@ -1,0 +1,39 @@
+/* 
+This function is called to POST a new line item each time a card is added to the basket.
+iteration 1, this will simply add the item to the reserved cards
+
+this is expecting the full item to be handed off (might be better to just be inventory id?)
+
+*/
+
+import axios from 'axios';
+import getReservedCardsList from './getReservedCardsList';
+
+export default function addLineItem(item, onSuccess, onFailure){
+
+    axios.post('lineitem/', {
+        //it's ok that this is 0, because there is no reservation to attach it to, yet.
+        //the card is reserved, but just floating out there without a 'reservation' yet.
+        id_reservation: 0,
+        //hold means that the item is held by a user, perhaps by putting it in their basket
+        hold: true,
+        id_inventory: item.inventory_id,
+      })
+      .then(function (response) {
+        console.log(response);
+        if (typeof onSuccess == 'function'){
+            onSuccess()
+        }
+        //this is where the reserved cards list must be updated, 
+        //it will only do this when successful, so we can just update the redux store here (can we?)
+        getReservedCardsList()
+      })
+      .catch(function (error) {
+        console.log('in the catch')
+        console.log(error);
+        if (typeof onFailure == 'function'){
+            onFailure()
+        }
+      });
+
+}

--- a/sylvan-library/src/apiActions/getReservedCardsList.js
+++ b/sylvan-library/src/apiActions/getReservedCardsList.js
@@ -17,7 +17,7 @@ export default function getReservedCardsList() {
 
     return axios.get(baseURL + 'lineitem/', {
         params: {
-            reserved: true
+            hold: true
         }
     })
         .then((response) => {

--- a/sylvan-library/src/utilities/AvailabilityCheck.js
+++ b/sylvan-library/src/utilities/AvailabilityCheck.js
@@ -16,8 +16,14 @@ export default function AvailabilityCheck() {
     )
 
     function compareLists(inState, fromAPI) {
-        let arr1 = inState.toSorted((a, b) => a - b)
-        let arr2 = fromAPI.toSorted((a, b) => a - b)
+        let arr1 = []
+        let arr2 = []
+        if (inState && inState.length){
+            arr1 = inState.toSorted((a, b) => a - b)
+        }
+        if (fromAPI && fromAPI.length){
+            arr2 = fromAPI.toSorted((a, b) => a - b)
+        }
 
         if (arr1.length != arr2.length) {
             return false
@@ -40,7 +46,6 @@ export default function AvailabilityCheck() {
     }
 
     useEffect(() => {
-        console.log('in the useEffect')
         if(!compareLists(reservedCardsInState, currentReservedCards)){
             updateReservedCardsList(currentReservedCards)
         }


### PR DESCRIPTION
Setup the toast infrastructure:  You can import and call successToast('message') anywhere in the app to display a success toast with 'message' as the text.  Same with errorToast, warningToast, and infoToast.

When you click reserve in the Search results, a lineitem is created on the backend and the hold=true

This is paired with some backend migrations that changed the name and stuff for the fields, and implements a custom save method that handles the timestamping in a way that doesn't break like auto-now, which has fucked up like 3x so far.

If testing, and you want to mark something as not on hold anymore, that currently needs to be done in django-admin by manually altering the row.

Stuff to do that's not part of this ticket:

- When an item is added to the basket, it should disappear from the search results(probably by updating the state and forcing the searchbar to rerender)
- when an item is added to the basket, it should not be able to be clicked and added again.
- when an item is removed from the basket, it should be marked as hold=false
